### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,10 @@
 name: Docker Build and Deploy
 
+permissions:
+  contents: read
+  packages: write
+  pull-requests: read
+
 on:
   workflow_dispatch:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Xoin-devs/xoinbot/security/code-scanning/2](https://github.com/Xoin-devs/xoinbot/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow to define the minimal permissions required for the `GITHUB_TOKEN`. Based on the operations in the workflow, the following permissions are needed:
- `contents: read` for accessing the repository contents.
- `packages: write` for pushing Docker images to the GitHub Container Registry.
- `pull-requests: read` for accessing pull request labels.

The `permissions` block will be added at the root level to apply to all jobs in the workflow. If any job requires additional permissions, they can be specified within the job itself.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
